### PR TITLE
Update default aria bin path for issue #4

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,7 @@ Assumes the aria2 RPC server is available at localhost:6800
 
 Example Debian init script to put in ```/etc/init.d/```
 
-It is set up for my own installation on Debian Squeeze (see instructions below).  If you're using a recent version of Ubuntu and its packaged version
-of aria2 you will want to change ```/opt/aria2/bin``` for ```/usr/bin```
+It is set up for Ubuntu 17.04 (Zesty's) packaged aria2c from the package "aria2" (see instructions below).  If you're using Debian Squeeze you will want to change ```/usr/bin``` for ```/opt/aria2/bin``` and follow the instructions to install into ```/opt/aria2``` below.
 
 ## initscript/aria2.conf
 

--- a/initscript/aria2c
+++ b/initscript/aria2c
@@ -11,7 +11,7 @@
 ### END INIT INFO
 
 NAME=aria2c
-ARIA2C=/opt/aria2/bin/$NAME
+ARIA2C=/usr/bin/$NAME
 PIDFILE=/var/run/$NAME.pid
 CONF=/etc/aria2.conf
 ARGS="--conf-path=${CONF}"


### PR DESCRIPTION
I realise that up to date operating systems have the right version of aria2 packaged now, so probably no reason for the default to be to run it from /opt/aria2/bin.

I haven't tested this myself, and am not currently using this tool myself, so I'm looking for someone else to review my updates and confirm they are sensible for a more up to date Debian or Ubuntu system before I merge them.